### PR TITLE
Fix typo in development guide

### DIFF
--- a/doc/Development.md
+++ b/doc/Development.md
@@ -20,7 +20,7 @@ yarn install
 yarn start
 ```
 
-This should open Tauntaun in your OS default brower.
+This should open Tauntaun in your OS default browser.
 
 ## Backend
 


### PR DESCRIPTION
## Summary
- correct spelling of "browser" in setup instructions

## Testing
- `poetry run pytest -q` *(fails: AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684753b6c020832499e53386c2d21fb3