### PR TITLE
Fix README Windows path example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ I recommend checking dev builds if something is missing(e.g. new weapon) or brok
 #### Configuration
 Configuration can be found at
 ```
-Windows: C:/<User>/AppData/Roaming/tauntaun_live_editor/config.json
+Windows: C:/<User>/AppData/Roaming/tauntaun-live-editor/config.json
 ```
 admin_password: password in SHA256 format, default is 1234
 #### Run server


### PR DESCRIPTION
## Summary
- correct config path in Windows example

## Testing
- `poetry run pytest -q` *(fails: 'Caucasus' object has no attribute 'batumi')*

------
https://chatgpt.com/codex/tasks/task_e_684754fe7e188324860734e3f2c11886